### PR TITLE
[bugfix]: tips is not complete when language value include '\n' nums …

### DIFF
--- a/src/link/I18nLinkProvider.ts
+++ b/src/link/I18nLinkProvider.ts
@@ -18,7 +18,6 @@ class I18nLinkProvider implements DocumentLinkProvider {
     _: CancellationToken
   ): ProviderResult<DocumentLink[]> {
     const result: DocumentLink[] = [];
-    console.log(1);
     const ast = this._astTool.parse(document.getText());
     if (AstTool.astParseError(ast)) {
       return;
@@ -35,7 +34,6 @@ class I18nLinkProvider implements DocumentLinkProvider {
       }
       const start = new Position(param.start.line, param.start.column);
       const end = new Position(param.end.line, param.end.column);
-      console.log(languageFile.get(param.paramsValue));
       result.push(
         new DocumentLink(
           new Range(start, end),

--- a/src/tool/AstTool.ts
+++ b/src/tool/AstTool.ts
@@ -174,8 +174,8 @@ class AstTool {
           );
         } else if (this.isStringLiteral(property.value)) {
           let value = property.value.value;
-          if (value.includes('\n')) {
-            value = value.replace('\n', '').replace('\r', '');
+          if (value.includes('\n') || value.includes('\r')) {
+            value = value.replace(/\n/g, '').replace(/\r/g, '');
           }
           let newKey = key;
           if (prefix.length > 0) {


### PR DESCRIPTION
[bugfix]: tips is not complete when language value include '\n' nums more than 1